### PR TITLE
Umożliwienie ustawiania opcji dla curla

### DIFF
--- a/src/NKHttpClient.php
+++ b/src/NKHttpClient.php
@@ -45,8 +45,12 @@ class NKHttpClient
   private $curl;
   private $response;
   private $response_code = 0;
+  
+  protected function getCurl() {
+    return $this->curl;
+  }
 
-  private function initCurl()
+  protected function initCurl()
   {
     if (null === $this->curl) {
       $this->curl = curl_init();

--- a/src/NKHttpClient.php
+++ b/src/NKHttpClient.php
@@ -46,7 +46,8 @@ class NKHttpClient
   private $response;
   private $response_code = 0;
   
-  protected function getCurl() {
+  protected function getCurl()
+  {
     return $this->curl;
   }
 


### PR DESCRIPTION
Obecnie nie da się ustawić customowych opcji curlowi bo cały dostęp do niego jest prywatny. Zwiększenie widoczności initCurl i dodanie getCurl pozwoli na przeciążanie tej klasy bez copypasty.
